### PR TITLE
Fixed typo in vfsStream package name

### DIFF
--- a/src/Inspectors/ByPackageNameInspector.php
+++ b/src/Inspectors/ByPackageNameInspector.php
@@ -49,7 +49,7 @@ final class ByPackageNameInspector implements InspectorContract
         'humbug/humbug',
         'infection/infection',
         'mockery/mockery',
-        'mikey179/vfsStream',
+        'mikey179/vfsstream',
         'phing/phing',
 
         /* SCA and code quality tools */


### PR DESCRIPTION
Package name `vfsStream` has changed its name to `vfsstream`